### PR TITLE
ci(action): further reduce load on CI

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -7,9 +7,13 @@ on:
   pull_request:
     paths:
       - 'docker/**'
-  merge_group:
   push:
     branches: ['main']
+    paths:
+      - 'docker/**'
+  schedule:
+    # Sunday midnight
+    - cron: '0 0 * * 0'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
- trigger on 'merge_group' and 'push to main' only if changes in docker files, so that pull requests do not trigger so many jobs
- add weekly build (Sunday midnight)